### PR TITLE
Change applicationId

### DIFF
--- a/data.usa.can/build.gradle
+++ b/data.usa.can/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 19
     buildToolsVersion "25.0.0"
     defaultConfig {
-        applicationId 'player.efis.data'
+        applicationId 'player.efis.data.usa.can'
         minSdkVersion 9
         targetSdkVersion 10
         //versionCode 1


### PR DESCRIPTION
On F-Droid you specified the applicationId to be  `player.efis.data.usa.can` as `player.efis.data` is infact already taken.